### PR TITLE
Update Enterzone and Exitzone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 Discord - https://discord.gg/3WYz3zaqG5
+Preview and Installation - https://youtu.be/8VZvy2uf3sE
 
 # SAYER-GANGS FRAMEWORK
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -169,19 +169,23 @@ function UpdateGangBlips()
 end
 
 function OnEnterZone(zoneName)
-    DebugCode('entered zone '..zoneName)
-    local gang = GetGang()
-    if not Gangs[gang.name] then return end
-    TriggerServerEvent('sayer-gangs:ZoneUpdate',zoneName, 'enter')
-    myZone = zoneName
+    DebugCode('entered zone ' .. zoneName)
+    CreateThread(function()
+        local gang = GetGang()
+        if not Gangs[gang.name] then return end
+        TriggerServerEvent('sayer-gangs:ZoneUpdate', zoneName, 'enter')
+        myZone = zoneName
+    end)
 end
- 
+
 function OnExitZone(zoneName)
-    DebugCode('exited zone '..zoneName)
-    local gang = GetGang()
-    if not Gangs[gang.name] then return end
-    TriggerServerEvent('sayer-gangs:ZoneUpdate',zoneName, 'exit')
-    myZone = nil
+    DebugCode('exited zone ' .. zoneName)
+    CreateThread(function()
+        local gang = GetGang()
+        if not Gangs[gang.name] then return end
+        TriggerServerEvent('sayer-gangs:ZoneUpdate', zoneName, 'exit')
+        myZone = nil
+    end)
 end
  
 function InsideZone(zoneName) --happens every frame for player in zone (useful for markers etc)

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -2,12 +2,14 @@
 
 function GetGang()
     local gang = 'none'
+    local promise = promise.new()
     QBCore.Functions.TriggerCallback('sayer-gangs:GetGang', function(result)
         if result then
             gang = result
         end
+        promise:resolve(gang)
     end)
-    return gang
+    return Citizen.Await(promise)
 end
 exports('GetGang', GetGang)
 


### PR DESCRIPTION
By using a promise with Citizen.Await, we force Lua to wait until the callback returns the actual gang data before continuing. This ensures that GetGang() returns the correct table with a valid name
Refactored the OnEnterZone and OnExitZone callbacks by wrapping asynchronous calls in CreateThread. This update ensures that asynchronous tasks (like retrieving gang data via GetGang()) complete properly before triggering server events, resolving issues with incomplete or default data being used when players cross zone boundaries.